### PR TITLE
Fixes for minor setup bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ Random Reward for YNAB (RRY) requires the following Python libraries for functio
 * [Requests](https://requests.readthedocs.io/en/master/)
 * [Arrow](https://arrow.readthedocs.io/en/stable/)
 
-Ensure that these are installed before proceeding.
+Ensure that these are installed before proceeding:
+
+```shell
+$ python3 -m pip install -r requirements.txt
+```
 
 ## Installation and Setup
 First, you need to download a copy of RRY onto your computer. This can be done in a number of ways. You can clone the repo onto your local machine by using the command below:
@@ -40,21 +44,21 @@ Once you have downloaded the project, you will need to edit `parameters.json` to
 
 We will go through each of these parameters in turn. First of all you will need a security token, which allows RRY to communicate with your YNAB account. You can use [this guide from YNAB](https://api.youneedabudget.com/#personal-access-tokens) to create a token. Copy the token to your clipboard and replace "Put Token Here" with it, keeping the quotation marks. IMPORTANT NOTE: Do not share your token with anyone. Use it only with your local copy of RRY.
 
-Besides the token, the remaining paramters are largely self-explanatory. Budget and category IDs should be left as null, as they will be assigned by `setup.py`; if for some reason you want to enter them manually you may, but this is not recommended. Budget and category names must match exactly, including spaces and capitalization. `category_from` refers to the category you wish to transfer money out of, and `category_to` refers to the category you wish to transfer money into. `amount` is the amount of money in dollars that should be transferred. `random_threshold` is the probablity that money will be transferred each time you run RRY. The default value of 0.5 corresponds to a 50% chance for transfer each time; 0.1 would correspond to 10%, and so on.
+Besides the token, the remaining paramters are largely self-explanatory. Budget and category IDs should be left as null, as they will be assigned by `ynab_setup.py`; if for some reason you want to enter them manually you may, but this is not recommended. Budget and category names must match exactly, including spaces and capitalization. `category_from` refers to the category you wish to transfer money out of, and `category_to` refers to the category you wish to transfer money into. `amount` is the amount of money in dollars that should be transferred. `random_threshold` is the probablity that money will be transferred each time you run RRY. The default value of 0.5 corresponds to a 50% chance for transfer each time; 0.1 would correspond to 10%, and so on.
 
-Once you have set the parameters to refelct your YNAB setup, run `setup.py` using the following command:
+Once you have set the parameters to reflect your YNAB setup, run `ynab_setup.py` using the following command:
 
 ```shell
-~/.../random_reward_for_ynab$ python setup.py
+$ python ynab_setup.py
 ```
 
-Assuming `setup.py` does not encounter an error, you are now ready to begin random rewards!
+Assuming `ynab_setup.py` does not encounter an error, you are now ready to begin random rewards!
 
 ## Usage
 The idea behind RRY is that intermittent reinforcement is more effective than consistent reinforcement; if you recieve an award every time you complete a task you will complete that task as often as you want the reward (assuming the task is easy). However, if you recieve a reward a random percentage of the time that you complete a task, you will be more likely to complete the task due to the unpredictibility of the reward. With that in mind, you should run RRY when you complete a task using the following command:
 
 ```shell
-~/.../random_reward_for_ynab$ python random_reward.py
+$ python random_reward.py
 ```
 
 RRY will then generate a random number and transfer money into your designated account if that number is greater than `random_threshold`. Enjoy your intermittent reinforcement!

--- a/README.md
+++ b/README.md
@@ -42,7 +42,14 @@ Once you have downloaded the project, you will need to edit `parameters.json` to
 }
 ```
 
-We will go through each of these parameters in turn. First of all you will need a security token, which allows RRY to communicate with your YNAB account. You can use [this guide from YNAB](https://api.youneedabudget.com/#personal-access-tokens) to create a token. Copy the token to your clipboard and replace "Put Token Here" with it, keeping the quotation marks. IMPORTANT NOTE: Do not share your token with anyone. Use it only with your local copy of RRY.
+We will go through each of these parameters in turn. First of all you will need a security token, which allows RRY to communicate with your YNAB account. You can use [this guide from YNAB](https://api.youneedabudget.com/#personal-access-tokens) to create a token. Copy the token to your clipboard and replace "Put Token Here" with it, keeping the quotation marks.
+
+IMPORTANT NOTE: Do not share your token with anyone. Use it only with your local copy of RRY.  It's a good idea to run
+
+```shell
+$ git update-index --assume-unchanged parameters.json
+```
+so you don't accidentally commit your YNAB API token.
 
 Besides the token, the remaining paramters are largely self-explanatory. Budget and category IDs should be left as null, as they will be assigned by `ynab_setup.py`; if for some reason you want to enter them manually you may, but this is not recommended. Budget and category names must match exactly, including spaces and capitalization. `category_from` refers to the category you wish to transfer money out of, and `category_to` refers to the category you wish to transfer money into. `amount` is the amount of money in dollars that should be transferred. `random_threshold` is the probablity that money will be transferred each time you run RRY. The default value of 0.5 corresponds to a 50% chance for transfer each time; 0.1 would correspond to 10%, and so on.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+arrow>=1.0.3
+requests>=2.25.1

--- a/ynab_setup.py
+++ b/ynab_setup.py
@@ -37,4 +37,4 @@ f = open('parameters.json', 'w')
 with f as outfile:
 	json.dump(new_params, outfile, indent=4)
 
-print("Setup complete! Run ynab_intermittent_reward.py to begin random rewards!")
+print("Setup complete! Run random_reward.py to begin random rewards!")


### PR DESCRIPTION
Small fixes based on my experience setting up random_reward_for_ynab:

* Add a `requirements.txt` so the dependencies can easily be installed with pip
* Rename `setup.py` to `ynab_setup.py` to avoid confusion with [distutils `setup.py`](https://stackoverflow.com/questions/1471994/what-is-setup-py)
* Fix message printed by `ynab_setup.py` so it no longer refers to `ynab_intermittent_reward.py`
* Edit README to reflect these changes (and also minor typo fixes)
* Add a note to the README that users should run `git update-index --assume-unchanged parameters.json` to avoid accidentally committing the YNAB token